### PR TITLE
chore: `max-result-count` isn't required

### DIFF
--- a/dist/index.js
+++ b/dist/index.js
@@ -5925,9 +5925,7 @@ ${limitedResults.map(template).join("\n")}
 async function run() {
   try {
     const eslintRemoteTesterConfig = core3.getInput("eslint-remote-tester-config", {required: true});
-    const maxResultCount = core3.getInput("max-result-count", {
-      required: true
-    });
+    const maxResultCount = core3.getInput("max-result-count");
     const workingDirectory = core3.getInput("working-directory");
     if (workingDirectory) {
       process.chdir(import_path3.default.join(process.cwd(), workingDirectory));

--- a/src/index.ts
+++ b/src/index.ts
@@ -13,9 +13,7 @@ async function run() {
             'eslint-remote-tester-config',
             { required: true }
         );
-        const maxResultCount = core.getInput('max-result-count', {
-            required: true,
-        });
+        const maxResultCount = core.getInput('max-result-count');
 
         const workingDirectory = core.getInput('working-directory');
         if (workingDirectory) {


### PR DESCRIPTION
https://github.com/AriPerkkio/eslint-remote-tester-run-action/blob/210db6833825a974d48bc567a2558461853cc6b1/action.yml#L21-L24