### PR TITLE
feat: enable `CI` by default

### DIFF
--- a/src/run-tester.ts
+++ b/src/run-tester.ts
@@ -16,6 +16,7 @@ export const RESULTS_TMP = '/tmp/results.json';
  */
 const DEFAULT_CONFIG: Partial<Config> = {
     cache: false,
+    CI: true,
 };
 
 // prettier-ignore


### PR DESCRIPTION
It's already `true` when run through this action, but this makes it explicit