### PR TITLE
feat: include count of scanned repositories into results comment

### DIFF
--- a/package.json
+++ b/package.json
@@ -17,7 +17,7 @@
         "@actions/core": "^1.2.6",
         "@actions/exec": "^1.0.4",
         "@actions/github": "^4.0.0",
-        "eslint-remote-tester": "^1.0.1",
+        "eslint-remote-tester": "^1.2.0",
         "semver": "^7.3.4"
     },
     "devDependencies": {

--- a/src/comment-templates.ts
+++ b/src/comment-templates.ts
@@ -23,6 +23,7 @@ ${error.stack}
  */
 export const COMMENT_TEMPLATE = (
     results: Result[],
+    repositoryCount: number | undefined,
     maxResultCount: number
 ): string => {
     const { RESULT_PARSER_TO_COMPARE_TEMPLATE } = requirePeerDependency(
@@ -35,7 +36,8 @@ export const COMMENT_TEMPLATE = (
 
     // prettier-ignore
     return '' +
-`Detected ${results.length} ESLint reports and/or crashes.
+`Detected ${results.length} ESLint reports and/or crashes. ${repositoryCount ? `
+Scanned ${repositoryCount} repositories.` : ''}
 ${limitReached ?
 `
 Reached maximum result count ${maxResultCount}.

--- a/src/run-tester.ts
+++ b/src/run-tester.ts
@@ -35,12 +35,12 @@ module.exports = {
     // Values from eslint-remote-tester-run-action's default configuration
     ...${JSON.stringify(DEFAULT_CONFIG, null, 4)},
 
-    onComplete: async function onComplete(results, comparisonResults) {
+    onComplete: async function onComplete(results, comparisonResults, repositoryCount) {
         // Write results to cache
-        fs.writeFileSync('${RESULTS_TMP}', JSON.stringify(results || []));
+        fs.writeFileSync('${RESULTS_TMP}', JSON.stringify({ results, repositoryCount }));
 
         if(usersConfig.onComplete) {
-            await usersConfig.onComplete(results, comparisonResults);
+            await usersConfig.onComplete(results, comparisonResults, repositoryCount);
         }
     }
 };

--- a/test/comment-templates.test.ts
+++ b/test/comment-templates.test.ts
@@ -22,11 +22,13 @@ describe('COMMENT_TEMPLATE', () => {
     test('results are shown in details', () => {
         const comment = COMMENT_TEMPLATE(
             [generateResult(1), generateResult(2)],
+            152,
             10
         );
 
         expect(comment).toMatchInlineSnapshot(`
-            "Detected 2 ESLint reports and/or crashes.
+            "Detected 2 ESLint reports and/or crashes. 
+            Scanned 152 repositories.
 
             <details>
                 <summary>Click to expand</summary>
@@ -67,11 +69,62 @@ describe('COMMENT_TEMPLATE', () => {
     test('results are limited based on maxResultCount', () => {
         const comment = COMMENT_TEMPLATE(
             [generateResult(1), generateResult(2), generateResult(3)],
+            1421,
             2
         );
 
         expect(comment).toMatchInlineSnapshot(`
-            "Detected 3 ESLint reports and/or crashes.
+            "Detected 3 ESLint reports and/or crashes. 
+            Scanned 1421 repositories.
+
+            Reached maximum result count 2.
+            Showing 2/3
+
+            <details>
+                <summary>Click to expand</summary>
+
+            ## Rule: rule-1
+
+            -   Message: \`message-1\`
+            -   Path: \`path-1\`
+            -   [Link](link-1)
+
+            \`\`\`extension-1
+            source-1
+            \`\`\`
+
+            \`\`\`
+            error-1
+            \`\`\`
+
+            ## Rule: rule-2
+
+            -   Message: \`message-2\`
+            -   Path: \`path-2\`
+            -   [Link](link-2)
+
+            \`\`\`extension-2
+            source-2
+            \`\`\`
+
+            \`\`\`
+            error-2
+            \`\`\`
+
+            </details>
+            "
+        `);
+    });
+
+    test("count of scanned repositories is not added when it's unavailable", () => {
+        const comment = COMMENT_TEMPLATE(
+            [generateResult(1), generateResult(2), generateResult(3)],
+            undefined,
+            2
+        );
+
+        expect(comment).toMatchInlineSnapshot(`
+            "Detected 3 ESLint reports and/or crashes. 
 
             Reached maximum result count 2.
             Showing 2/3

--- a/test/index.test.ts
+++ b/test/index.test.ts
@@ -14,7 +14,11 @@ const mockCore = {
 jest.mock('@actions/core', () => mockCore);
 
 const mockFs = {
-    readFileSync: jest.fn().mockReturnValue('[{"id": 1}, {"id": 2}]'),
+    readFileSync: jest
+        .fn()
+        .mockReturnValue(
+            '{ "results": [{"id": 1}, {"id": 2}], "repositoryCount": 1502 }'
+        ),
 };
 jest.mock('fs', () => mockFs);
 
@@ -74,6 +78,7 @@ describe('entrypoint', () => {
         );
         expect(mockCommentTemplate).toHaveBeenCalledWith(
             [{ id: 1 }, { id: 2 }],
+            1502,
             999
         );
     });

--- a/test/run-tester.test.ts
+++ b/test/run-tester.test.ts
@@ -63,12 +63,12 @@ describe('run-tester', () => {
 
         expect(sanitizeStackTrace(readRunConfig().onComplete!.toString()))
             .toMatchInlineSnapshot(`
-            "async function onComplete(results, comparisonResults) {
+            "async function onComplete(results, comparisonResults, repositoryCount) {
                     // Write results to cache
-                    fs.writeFileSync('/tmp/results.json', JSON.stringify(results || []));
+                    fs.writeFileSync('/tmp/results.json', JSON.stringify({ results, repositoryCount }));
 
                     if(usersConfig.onComplete) {
-                        await usersConfig.onComplete(results, comparisonResults);
+                        await usersConfig.onComplete(results, comparisonResults, repositoryCount);
                     }
                 }"
         `);

--- a/yarn.lock
+++ b/yarn.lock
@@ -1952,10 +1952,10 @@ eslint-plugin-prettier@^3.3.1:
   dependencies:
     prettier-linter-helpers "^1.0.0"
 
-eslint-remote-tester@^1.0.1:
-  version "1.1.0"
-  resolved "https://registry.yarnpkg.com/eslint-remote-tester/-/eslint-remote-tester-1.1.0.tgz#d4a5d69c89b1eda5c492b39afb4023b9c3b15317"
-  integrity sha512-amEmEDEJZ0h2ZYU9EV/Fryu6mc/7OVmQdz3mOmWcYV8MJl2j/y7BmOhnKb9DqJT5P8PP2jprBCzqzklt84zHsw==
+eslint-remote-tester@^1.2.0:
+  version "1.2.0"
+  resolved "https://registry.yarnpkg.com/eslint-remote-tester/-/eslint-remote-tester-1.2.0.tgz#eea8cb72b60de530b0f10a2af0d54c13e0713f95"
+  integrity sha512-VwippmgzkMbcLG3qK6JekmN1K1LfKXHVLh++xz+8jBZddWxEI+XMcZk9fOVPTMuNmJOdHogMgp/sptPfaBZC3Q==
   dependencies:
     "@babel/code-frame" "^7.12.13"
     JSONStream "^1.3.5"


### PR DESCRIPTION
- Optional feature enabled when eslint-remote-tester@1.2.0 is available

Closes #13 