### PR TITLE
chore: add permission to readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,6 +38,10 @@ on:
     schedule: # Every thursday at 00:00
         - cron: '0 00 * * THU'
 
+# Give the workflow permission to create the result issue
+permissions:
+  issues: write
+
 jobs:
     test:
         runs-on: ubuntu-latest


### PR DESCRIPTION
It seems in some cases, the permissions need to be defined explicitly. I suppose the default changed since this action was originally published or some such thing.

Setting this permission makes the issue creation work.